### PR TITLE
improve speed in unpaste

### DIFF
--- a/unpaste
+++ b/unpaste
@@ -42,13 +42,13 @@ if __name__ == '__main__':
         line = line.rstrip('\n')
         fields = line.split(args.delimiter, maxsplit=len(fhs)-1)
         for i, field in enumerate(fields):
-            print(field, file=fhs[i], flush=True)
+            print(field, file=fhs[i])
 
         for i in range(len(fields), len(fhs)):
-            print(file=fhs[i], flush=True)
+            print(file=fhs[i])
 
         if args.tee:
-            print(line, flush=True)
+            print(line)
 
     for fh in fhs:
         fh.close()


### PR DESCRIPTION
`unpaste` is a bit slow because it forces a flush in each write. This PR addresses that latency. Microbenchmark info below.


Data generation

```python
>>> with open('in.txt', 'w') as f:
...    for i in range(N):
...        print(i, file=f)
...
>>> with open('in2.txt', 'w') as f:
...    for i in range(N):
...        print(i, file=f)
...
```

Apples-to-apples
```bash
(base) ➜  ~ time paste in.txt in2.txt | python unpaste.py out.txt out2.txt
paste in.txt in2.txt  17.81s user 0.39s system 9% cpu 3:17.18 total
python unpaste.py out.txt out2.txt  90.09s user 102.49s system 97% cpu 3:17.39 total
(base) ➜  ~ diff in.txt out.txt
(base) ➜  ~ diff in2.txt out2.txt
(base) ➜  ~ time paste in.txt in2.txt | python unpaste_no_flush.py out.txt out2.txt
paste in.txt in2.txt  16.99s user 0.23s system 57% cpu 29.845 total
python unpaste_no_flush.py out.txt out2.txt  28.83s user 0.37s system 97% cpu 29.905 total
(base) ➜  ~ diff in.txt out.txt
(base) ➜  ~ diff in2.txt out2.txt
```