### PR TITLE
add signal handling

### DIFF
--- a/cmap
+++ b/cmap
@@ -9,10 +9,12 @@ Usage:
 Original author: Elijah Rippeth (@erip)
 """
 
-from io import StringIO
-
 import subprocess
+from signal import signal, SIGPIPE, SIG_DFL
 from argparse import ArgumentParser, FileType, REMAINDER
+
+# Silence broken pipes when downstream stops reading; e.g., piping to `head`
+signal(SIGPIPE, SIG_DFL)
 
 def setup_argparse():
     parser = ArgumentParser()


### PR DESCRIPTION
If a downstream utility stops reading prematurely (like piping to `head`), the script currently throws a `BrokenPipeError`. This is frankly not too bad, but it's ugly and scary to a user so this PR swallows it.