### PR TITLE
"cache" the processes to improve speed

### DIFF
--- a/cmap
+++ b/cmap
@@ -8,6 +8,7 @@ Usage:
 
 Original author: Elijah Rippeth (@erip)
 """
+#!/usr/bin/env python3
 
 import subprocess
 
@@ -31,18 +32,16 @@ if __name__ == "__main__":
     if args.fields:
         rel_fields = [int(e)-1 for e in args.fields.split(",")]
 
-    procs = []
+    proc = subprocess.Popen(args.command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, bufsize=0)
     with args.input as fin, args.output as fout:
         for line in map(str.strip, fin):
             columns = line.split(args.delimiter)
             if args.fields:
                 columns = [columns[f] for f in rel_fields]
-            if len(procs) == 0:
-                procs = [subprocess.Popen(args.command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, bufsize=0) for _ in columns]
             output = []
             for i, col in enumerate(columns):
-                procs[i].stdin.write((col+"\n").encode())
-                procs[i].stdin.flush()
-                stdout = procs[i].stdout.readline()
+                proc.stdin.write((col+"\n").encode())
+                proc.stdin.flush()
+                stdout = proc.stdout.readline()
                 output.append(stdout.decode().strip())
             print(args.delimiter.join(output), file=fout)

--- a/cmap
+++ b/cmap
@@ -9,10 +9,13 @@ Usage:
 Original author: Elijah Rippeth (@erip)
 """
 
-from io import StringIO
-
 import subprocess
+
+from signal import signal, SIGPIPE, SIG_DFL
 from argparse import ArgumentParser, FileType, REMAINDER
+
+# Silence broken pipes when downstream stops reading; e.g., piping to `head`
+signal(SIGPIPE, SIG_DFL)
 
 def setup_argparse():
     parser = ArgumentParser()
@@ -28,14 +31,18 @@ if __name__ == "__main__":
     if args.fields:
         rel_fields = [int(e)-1 for e in args.fields.split(",")]
 
+    procs = []
     with args.input as fin, args.output as fout:
         for line in map(str.strip, fin):
             columns = line.split(args.delimiter)
             if args.fields:
                 columns = [columns[f] for f in rel_fields]
+            if len(procs) == 0:
+                procs = [subprocess.Popen(args.command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, bufsize=0) for _ in columns]
             output = []
-            for col in columns:
-                o = subprocess.Popen(args.command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, bufsize=0)
-                stdout = o.communicate(input=(col+"\n").encode())[0]
+            for i, col in enumerate(columns):
+                procs[i].stdin.write((col+"\n").encode())
+                procs[i].stdin.flush()
+                stdout = procs[i].stdout.readline()
                 output.append(stdout.decode().strip())
             print(args.delimiter.join(output), file=fout)

--- a/cmap
+++ b/cmap
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-[c]olumn [map]per --- applies a subcommand to each column of a delimited stream. 
+[c]olumn [map]per --- applies a subcommand to each column of a delimited stream. The provided subcommand must necessarily provide one line of stdout for each line consumed over stdin without buffering.
 
 Usage:
     paste <(echo "1+1") <(echo "2+2") <(echo "3+3") | cmap bc

--- a/cmap
+++ b/cmap
@@ -23,7 +23,7 @@ def setup_argparse():
     parser.add_argument("-d", "--delimiter", default="\t", help="The delimiter on which columns are read and written")
     parser.add_argument("-i", "--input", type=FileType("r"), default="-", help="The input stream")
     parser.add_argument("-o", "--output", type=FileType("w"), default="-", help="The output stream")
-    parser.add_argument("command", nargs=REMAINDER, help="The subcommand to be applied to all columns. Must necessarily produce one line of stdout for each line consumed over stdin without buffering.)
+    parser.add_argument("command", nargs=REMAINDER, help="The subcommand to be applied to all columns. Must necessarily produce one line of stdout for each line consumed over stdin without buffering.")
     return parser
 
 if __name__ == "__main__":

--- a/cmap
+++ b/cmap
@@ -23,7 +23,7 @@ def setup_argparse():
     parser.add_argument("-d", "--delimiter", default="\t", help="The delimiter on which columns are read and written")
     parser.add_argument("-i", "--input", type=FileType("r"), default="-", help="The input stream")
     parser.add_argument("-o", "--output", type=FileType("w"), default="-", help="The output stream")
-    parser.add_argument("command", nargs=REMAINDER)
+    parser.add_argument("command", nargs=REMAINDER, help="The subcommand to be applied to all columns. Must necessarily produce one line of stdout for each line consumed over stdin without buffering.)
     return parser
 
 if __name__ == "__main__":


### PR DESCRIPTION
After trying to apply the original `cmap` to a proper `spm_encode` workload, I found it to be brutally slow. This is due to launching `spm_encode` (assuming all of its startup costs) for each line. This PR treats the process(es) as a long-living one where each line is sent to a single-startup worker. Benchmark numbers below (`/usr/local/bin/cmap` is the one in master, `./cmap` is the proposed hotfix):

```bash
$ hyperfine 'paste train.en train.fr | head -n100 | ./cmap spm_encode --model test.model > out1' \
            'paste train.en train.fr | head -n100 | /usr/local/bin/cmap spm_encode --model test.model > out2'
Benchmark 1: paste train.en train.fr | head -n100 | ./cmap spm_encode --model test.model > out1
  Time (mean ± σ):      43.9 ms ±   2.0 ms    [User: 17.7 ms, System: 6.2 ms]
  Range (min … max):    40.5 ms …  49.8 ms    70 runs

Benchmark 2: paste train.en train.fr | head -n100 | /usr/local/bin/cmap spm_encode --model test.model > out2
  Time (mean ± σ):      2.792 s ±  0.019 s    [User: 2.445 s, System: 0.404 s]
  Range (min … max):    2.758 s …  2.826 s    10 runs

Summary
  'paste train.en train.fr | head -n100 | ./cmap spm_encode --model test.model > out1' ran
   63.61 ± 2.88 times faster than 'paste train.en train.fr | head -n100 | /usr/local/bin/cmap spm_encode --model test.model > out2'
$ diff out1 out2
$
```

63.6x faster isn't too shabby. 😄 